### PR TITLE
fix: odcs install issue

### DIFF
--- a/src/install.js
+++ b/src/install.js
@@ -16,6 +16,7 @@ const installPythonDependencies = () => {
 
 const installRequiredPipPackages = () => {
   core.info("Installing required PiP modules...");
+  child_process.execSync('pip3 install -U pip', {stdio: 'inherit'});
   child_process.execSync('pip3 install wheel', {stdio: 'inherit'});
   child_process.execSync('pip3 install odcs', {stdio: 'inherit'});
   child_process.execSync('pip3 install docker', {stdio: 'inherit'});


### PR DESCRIPTION
## Description
Transitive dependency on cryptography module from odcs module prevents dependency to install with the following StackTrace:

```
Collecting cryptography>=3.2 (from pyOpenSSL->odcs)
  Downloading https://files.pythonhosted.org/packages/27/5a/007acee0243186123a55423d49cbb5c15cb02d76dd1b6a27659a894b13a2/cryptography-3.4.4.tar.gz (545kB)
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-j6_46wx2/cryptography/setup.py", line 14, in <module>
        from setuptools_rust import RustExtension
    ModuleNotFoundError: No module named 'setuptools_rust'
    
            =============================DEBUG ASSISTANCE==========================
            If you are seeing an error here please try the following to
            successfully install cryptography:
    
            Upgrade to the latest pip and try again. This will fix errors for most
            users. See: https://pip.pypa.io/en/stable/installing/#upgrading-pip
            =============================DEBUG ASSISTANCE==========================
    
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-j6_46wx2/cryptography/
child_process.js:660
    throw err;
    ^

Error: Command failed: pip3 install odcs
```

Applying workaround suggested in: https://github.com/pyca/cryptography/issues/5753#issuecomment-775346078

## See also
- https://github.com/pyca/cryptography/issues/5753
- https://github.com/pyca/cryptography/issues/5806